### PR TITLE
Allow nested template strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,6 @@ function getErrorMessage(source, exception, filename) {
  */
 function template(tmpl, context, filename) {
 	filename = filename || 'untitled';
-	tmpl = tmpl.replace(/`/g, '\\`');
 	try {
 		return vm.runInNewContext('`' + tmpl + '`', context);
 	} catch (exception) {

--- a/test.js
+++ b/test.js
@@ -12,7 +12,7 @@ describe('template()', () => {
 	});
 
 	it('should escape `', () => {
-		const fn = () => template('Hello, `${foo}`!', { foo: 'Bar' });
+		const fn = () => template('Hello, \\`${foo}\\`!', { foo: 'Bar' });
 		expect(fn).not.toThrowError();
 
 		const result = fn();


### PR DESCRIPTION
This PR introduces a breaking change, since it will not escape `back ticks` anymore by default and one has to escape them explicitly. Ideally this is similar to the default behavior of template string.